### PR TITLE
Add useIntersections hook

### DIFF
--- a/examples/cra-site/src/App.css
+++ b/examples/cra-site/src/App.css
@@ -1,5 +1,7 @@
 .App {
   text-align: center;
+  background-color: #282c34;
+  color: white;
 }
 
 .App-logo {
@@ -9,14 +11,12 @@
 }
 
 .App-header {
-  background-color: #282c34;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   font-size: calc(10px + 2vmin);
-  color: white;
 }
 
 .App-link {

--- a/examples/cra-site/src/App.js
+++ b/examples/cra-site/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useFetcher } from '@hpe/react-hooks';
+import { useFetcher, useIntersection } from '@hpe/react-hooks';
 import logo from './logo.svg';
 import './App.css';
 
@@ -7,9 +7,11 @@ function App() {
   const [data, loading, error] = useFetcher(
     'https://api.openweathermap.org/data/2.5/weather?zip=27278&appid=18ef348ece45174572c5e3d4be8a8d69&units=imperial',
   );
+  const [thingToWatch, entry] = useIntersection();
+  const isVisible = entry.isIntersecting;
+
   return (
     <div className="App">
-      <div />
       <header className="App-header">
         {loading && <img src={logo} className="App-logo" alt="logo" />}
         {error && (
@@ -26,6 +28,21 @@ function App() {
           </div>
         )}
       </header>
+      <div style={{ height: '100vh' }} />
+      <div ref={thingToWatch}>
+        <h1
+          style={{
+            opacity: isVisible ? 1 : 0,
+            transition: 'opacity 1s ease-in',
+          }}
+        >
+          Im now in view{' '}
+          <span role="img" aria-label="eyes looking around">
+            👀
+          </span>
+        </h1>
+      </div>
+      <div style={{ height: '100vh' }} />
     </div>
   );
 }

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -1,14 +1,14 @@
 # HPE JS Reusable React Hooks
 
-A set of reusable React hooks to use in your React >= v16.8.0 projects.
+A set of reusable React hooks to use in your React >= v16.8.0 projects. To install the reusable hooks package run the following command in your project directory.
+`npm install -D @hpe/react-hooks` or `yarn add @hpe/react-hooks`
 
 ## useFetcher
 
 A set of hooks for fetching asynconchronus data. Uses `isomorphic-fetch` to allow for server-side rendering. Here's how to use this hook in your React project.
 
-1. `npm install -D @hpe/react-hooks` or `yarn add @hpe/react-hooks`
-2. Import the hook at the top of your componenet file `import { useFetcher } from '@hpe/react-hooks';`
-3. In your component add `const [data, loading, error] = useFetcher('https://myapi/data');`. When `data` is available it will return a json parsed object, `loading` returns a boolean to allow a loading state while `error` will provide any request errors the hook encountered.
+1. Import the hook at the top of your componenet file `import { useFetcher } from '@hpe/react-hooks';`
+2. In your component add `const [data, loading, error] = useFetcher('https://myapi/data');`. When `data` is available it will return a json parsed object, `loading` returns a boolean to allow a loading state while `error` will provide any request errors the hook encountered.
 
 `useFetcher` accepts a second parameter to accomplish more customized requests, the second parameter behaves exactly a standard `fetch` call. More information can be found in the [fetch spec](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Supplying_request_options).
 
@@ -43,4 +43,42 @@ function App() {
 }
 
 export default App;
+```
+
+## useIntersection
+
+A hook for observing when a DOM node or nodes enters or leaves a browser viewport. `useIntersection` accepts all parameters which the [Intersection Observer API spec](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) accepts including `root`, `rootMargin`, and `threshold`.
+
+_**Note:** this feature is not IE11 compatible without a [polyfill](https://github.com/w3c/IntersectionObserver/tree/master/polyfill)_
+
+Below is an example React application using the `useIntersection` hook.
+
+```javascript
+import React from 'react';
+import { useIntersection } from '@hpe/react-hooks';
+
+function App() {
+  const [thingToWatch, entry] = useIntersection();
+  const isVisible = entry.isIntersecting;
+
+  return (
+    <div>
+      <div style={{ height: '100vh' }} />
+      <div ref={thingToWatch}>
+        <h1
+          style={{
+            opacity: isVisible ? 1 : 0,
+            transition: 'opacity 1s ease-in',
+          }}
+        >
+          Im now in view{' '}
+          <span role="img" aria-label="eyes looking around">
+            👀
+          </span>
+        </h1>
+      </div>
+      <div style={{ height: '100vh' }} />
+    </div>
+  );
+}
 ```

--- a/packages/react-hooks/index.js
+++ b/packages/react-hooks/index.js
@@ -1,4 +1,5 @@
 // (C) Copyright 2019 Hewlett Packard Enterprise Development LP.
 import useFetcher from './src/useFetcher';
+import useIntersection from './src/useIntersection';
 
-export { useFetcher };
+export { useFetcher, useIntersection };

--- a/packages/react-hooks/src/useIntersection.js
+++ b/packages/react-hooks/src/useIntersection.js
@@ -1,0 +1,50 @@
+import { useState, useEffect, useRef } from 'react';
+
+export const useIntersection = ({
+  root = null, // defaults to viewport when null.
+  rootMargin, // expands or contracts the intersection root hit area
+  threshold = 0, // intersection ratio value, also accepts arrays
+  repeats = true,
+  debug = false,
+} = {}) => {
+  const [observerEntry, updateEntry] = useState({});
+  const [node, setNode] = useState(null);
+
+  const observer = useRef(
+    new window.IntersectionObserver(
+      ([currEntry]) => {
+        if (debug) console.log(currEntry); // eslint-disable-line no-console
+        // Only trigger once if repeat option is false
+        if (!repeats && currEntry.isIntersecting) {
+          // Pull the observer after the event fires
+          observer.current.disconnect();
+          updateEntry(currEntry);
+        }
+        if (repeats) {
+          updateEntry(currEntry);
+        }
+      },
+      {
+        root,
+        rootMargin,
+        threshold,
+      },
+    ),
+  );
+
+  useEffect(() => {
+    const { current: currentObserver } = observer;
+    currentObserver.disconnect();
+
+    if (node) currentObserver.observe(node);
+
+    return () => currentObserver.disconnect();
+  }, [node]);
+
+  return [
+    setNode, // Sets dom node to watch, expects a ref
+    observerEntry, // Intersection observer entry output
+  ];
+};
+
+export default useIntersection;


### PR DESCRIPTION
A hook for observing when a DOM node or nodes enters or leaves a browser viewport. `useIntersection` accepts all parameters which the [Intersection Observer API spec](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) accepts including `root`, `rootMargin`, and `threshold`.

_**Note:** this feature is not IE11 compatible without a [polyfill](https://github.com/w3c/IntersectionObserver/tree/master/polyfill)_

Below is an example React application using the `useIntersection` hook.

```javascript
import React from 'react';
import { useIntersection } from '@hpe/react-hooks';

function App() {
  const [thingToWatch, entry] = useIntersection();
  const isVisible = entry.isIntersecting;

  return (
    <div>
      <div style={{ height: '100vh' }} />
      <div ref={thingToWatch}>
        <h1
          style={{
            opacity: isVisible ? 1 : 0,
            transition: 'opacity 1s ease-in',
          }}
        >
          Im now in view{' '}
          <span role="img" aria-label="eyes looking around">
            👀
          </span>
        </h1>
      </div>
      <div style={{ height: '100vh' }} />
    </div>
  );
}
```
